### PR TITLE
Fix the preload issues

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,14 +15,21 @@
 	</script>
 
 	<script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
-	<script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
-			data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout"
+	<script id="sap-ui-bootstrap"
+			src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
+			data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout, sap.fe.core, sap.ui.table"
 			data-sap-ui-compatVersion="edge"
 			data-sap-ui-theme="sap_horizon"
+			data-sap-ui-async="true"
+			data-sap-ui-onInit="onInit"
 			data-sap-ui-frameOptions="allow"
 	></script>
 	<script>
-		sap.ui.getCore().attachInit(()=> sap.ushell.Container.createRenderer().placeAt("content"))
+		onInit = function() {
+				sap.ushell.Container.createRenderer(undefined, true).then(function (oRenderer) {
+					oRenderer.placeAt("content");
+				});
+		}
 	</script>
 
 </head>


### PR DESCRIPTION
- ui5 is being loaded synchronously which add lots of request for sap/ui/core resources
- the application are loaded with the App first and manifest second, this means that sap/fe/core at least needs to be declared in the data-sap-ui-libs (in standard FLP scenario the manifest is loaded first, thus resolving the dependencies)
- sap/ui/table is not declared as a dependency by anyone (should probably be sap/ui/mdc)

I'll follow up internally regarding point 1 and 3, for point 2 I don't think there is a way to avoid the declaration in the index.html